### PR TITLE
fix: Exempt pytest from exclude-newer to prevent Renovate PR loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,4 @@ packages = ["plugin"]
 
 [tool.uv]
 exclude-newer = "1 week"
+exclude-newer-package = { pytest = false }


### PR DESCRIPTION
Exempt pytest from the relative `exclude-newer` constraint to stop Renovate from creating duplicate security PRs.